### PR TITLE
Update Supervisely SDK to 6.73.564

### DIFF
--- a/config.json
+++ b/config.json
@@ -5,7 +5,7 @@
   "headless": false,
   "name": "Group nested objects",
   "description": "Binds nested objects into groups",
-  "docker_image": "supervisely/data-operations:6.73.564",
+  "docker_image": "supervisely/base-py-sdk-hardened:6.73.564",
   "icon": "https://user-images.githubusercontent.com/115161827/211062544-2fc9edf7-9258-43be-a362-3cb293a92fd2.jpg",
   "icon_cover": true,
   "poster": "https://user-images.githubusercontent.com/115161827/211063080-95d8fc82-7549-4859-97fd-361bcb5e0b20.png",

--- a/config.json
+++ b/config.json
@@ -5,7 +5,7 @@
   "headless": false,
   "name": "Group nested objects",
   "description": "Binds nested objects into groups",
-  "docker_image": "supervisely/data-operations:6.73.486",
+  "docker_image": "supervisely/data-operations:6.73.564",
   "icon": "https://user-images.githubusercontent.com/115161827/211062544-2fc9edf7-9258-43be-a362-3cb293a92fd2.jpg",
   "icon_cover": true,
   "poster": "https://user-images.githubusercontent.com/115161827/211063080-95d8fc82-7549-4859-97fd-361bcb5e0b20.png",

--- a/config.json
+++ b/config.json
@@ -21,5 +21,5 @@
       "images_dataset"
     ]
   },
-  "min_instance_version": "6.15.35"
+  "instance_version": "6.15.60"
 }

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,1 +1,1 @@
-supervisely
+supervisely==6.73.564


### PR DESCRIPTION
Updates default Supervisely Docker apps to Supervisely SDK `6.73.564`.

- Updates `docker_image` tags for default Supervisely images.
- Updates Supervisely SDK references in requirements and Dockerfiles.
- Does not release applications.

Validation: generated ecosystem inventory report.
